### PR TITLE
Change the post template to auto generate title

### DIFF
--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,5 +1,5 @@
 ---
-title: "Simple Runbook Template"
+title: "{{ replace .Name "-" " " | title }}"
 summary: "Summary here"
 ---
 


### PR DESCRIPTION
We can automatically generate a page title from the name of the post so
I think we should do so.