### PR TITLE
Respect doNotTrack if the viewer has set this

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,9 @@ enableGitInfo = "true"
 
 googleAnalytics = "UA-53586058-2"
 
+[privacy.googleAnalytics]
+respectDoNotTrack = true
+
 [params]
 showFooterCredits = false
 


### PR DESCRIPTION
I've just noticed that Hugo disables this by default which seems like a
very bad idea as it is actively overriding what the viewer has set as
their preference.