### PR TITLE
Add "Improve this page" link

### DIFF
--- a/layouts/partials/header_links.html
+++ b/layouts/partials/header_links.html
@@ -14,7 +14,7 @@
         <a href="{{$repository }}{{ $repo_path }}" class="edit-link">
           <svg aria-hidden="true" height="16" role="img" viewBox="0 0 14 16" width="14" class="pencil">
             <path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 011.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"></path>
-          </svg>
+          </svg>&nbsp;
           {{ $link_text }}
         </a>
       </span>

--- a/layouts/partials/header_links.html
+++ b/layouts/partials/header_links.html
@@ -1,0 +1,22 @@
+{{ $repository := "https://github.com/containersolutions/runbooks"}}
+{{/* Index pages only contain the title so we link to issues instead */}}
+{{ $index_page := .File.Filename | findRE "_index\\.md$" }}
+{{ $repo_path := "/issues" }}
+{{ $link_text := "Suggest a change" }}
+{{ if not $index_page }}
+  {{ $repo_path = .File.Filename | replaceRE "^.*/content/(.*)" "/edit/master/content/$1" }}
+  {{ $link_text = "Improve this page" }}
+{{ end }}
+<!-- edit-header -->
+  <div class="pseudo-menu-item text-gray">
+    <div class="pseudo-flex-item">
+      <span class="pseudo-nav-item">
+        <a href="{{$repository }}{{ $repo_path }}" class="edit-link">
+          <svg aria-hidden="true" height="16" role="img" viewBox="0 0 14 16" width="14" class="pencil">
+            <path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 011.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"></path>
+          </svg>
+          {{ $link_text }}
+        </a>
+      </span>
+    </div>
+  </div>

--- a/static/assets/custom_style.css
+++ b/static/assets/custom_style.css
@@ -41,3 +41,62 @@ div#holy {
 .spaced-list li{
   margin-bottom: 16px;
 }
+
+.edit-header {
+  /* display: flex; */
+  /* width: 100%; */
+  /* position: sticky; */
+  /* justify-content: flex-end; */
+  padding: 17px 5px 16px 5px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #586069;
+  text-align: center;
+}
+
+.pseudo-menu-item {
+  display: flex;
+  margin-bottom: -1px;
+}
+
+.pseudo-flex-item {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  position: relative;
+}
+
+.pseudo-nav-item {
+  padding: 16px 8px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #586069;
+  text-align: center;
+  border-bottom: 2px solid transparent;
+}
+
+@media only screen and (min-width: 1400px) {
+  .pseudo-menu-item {
+    display: flex;
+    position: fixed;
+    margin-right: 15px;
+    top: 0;
+    right: 0;
+  }
+
+  #header {
+    margin-top: 10px;
+  }
+}
+
+.pencil {
+  display:inline-block;
+  fill:currentColor;
+  /* user-select:none; */
+  vertical-align:text-bottom
+}
+
+.edit-link {
+  color: #586069 !important;
+  text-decoration: none;
+}


### PR DESCRIPTION
For some _index pages this isn't appropriate as it normally only
displays the title with the body being autogenerated. For such cases I'm
asking the user to "Suggest a change" instead and linking them to the
issues page.

I've included a free icon for the pencil from Github's Octicons
(https://primer.style/octicons/) resource. It uses the MIT license
and we are not using "substantial portions of the Software". However
here is the link to that license anyway:
https://github.com/primer/octicons/blob/e9a9a84fb796d70c0803ab8d62eda5c03415e015/LICENSE

I've inlined the SVG as it's currently only being used in one location
and is quite small so I believe this leads to faster loading.