### PR TITLE
Add theme to help with debugging Hugo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/hugo-primer-cs"]
 	path = themes/hugo-primer-cs
 	url = https://github.com/ContainerSolutions/hugo-primer
+[submodule "themes/hugo-debugprint"]
+	path = themes/hugo-debugprint
+	url = https://github.com/kaushalmodi/hugo-debugprint

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ To update the key used
 
 More granular details are available on the [action page](https://github.com/containersolutions/gh-actions-hugo-deploy-gh-pages#secrets).
 
+## Debugging
+
+The Hugo docs can occasionally be a bit vague about what methods are available or what they return. There also seems to be quite a bit of [push](https://github.com/gohugoio/hugo/issues/4081#issuecomment-442384273)-[back](https://github.com/gohugoio/hugo/issues/3957#issuecomment-364657015) to adding general debugging tools. One user has created a theme that includes a partial and a shortcode to work around this limitation.
+
+If you are working from inside a partial or layout file you can include the following partial and pass the property that you wish to inspect. I'm using `.File` in the example below.
+
+    {{ partial "debugprint.html" .File }}
+
+This will show you various properties available via `.File`.
+
+If working within a content file things are a lot more limited but you can pass the following variants to get appropriate output:
+
+    {{< debug "params" >}}
+    {{< debug "site" >}}
+    {{< debug param="title" >}}
+
+but generally you will get more use when invoking the `debugprint` partial directly.
+
 ## License
 
 See [LICENSE](LICENSE)

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://containersolutions.github.io/runbooks/"
 languageCode = "en-us"
 title = "Runbooks"
-theme = "hugo-primer-cs"
+theme = ["hugo-debugprint", "hugo-primer-cs"]
 
 disqusShortname = "runbooks"
 enableGitInfo = "true"


### PR DESCRIPTION
There has unfortunately been some pushback with adding general debugging
tools to Hugo

https://github.com/gohugoio/hugo/issues/4081#issuecomment-442384273
https://github.com/gohugoio/hugo/issues/3957#issuecomment-364657015

I've found this can make things a lot more difficult than it needs
to be. There appears to be a belief that adding debugging tools will
lead to people using things that are undocumented. Unfortunately in my
experience I've had trouble with values that are documented but where
the documentation isn't very clear.

Even where debugging tools are provided the output is minified and
requests to change this have so far been rejected for the same reason as
above.

A user has developed a theme which can work around many of these issues
and add a convenient debugging partial to allow you to clearly see the
contents of most variables. (see README changes for more specifics.)