### PR TITLE
Minor Docker related tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ docker-compose up
 Alternatively, without docker compose:
 
 ```
-$ docker build -t runbooks-hugo
+$ docker build -t runbooks-hugo .
 ...
 $ docker run -v $PWD:/src -p 1313:1313 -d runbooks-hugo
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ git clone --recursive git@github.com:ContainerSolutions/runbooks.git
 If you have docker compose installed you can simply call and you should see the blog at http://localhost:1313/runbooks/
 
 ```
-docker-compose up
+$ docker-compose up
+```
+
+Alternatively, without docker compose:
+
+```
+$ docker build -t runbooks-hugo
+...
+$ docker run -v $PWD:/src -p 1313:1313 -d runbooks-hugo
 ```
 
 #### Local Install (runs really fast)

--- a/docker/hugo_serve.sh
+++ b/docker/hugo_serve.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # hugo serve -D --bind="0.0.0.0"
 
-hugo -D --watch=true --bind="0.0.0.0" serve
+exec hugo -D --watch=true --bind="0.0.0.0" serve


### PR DESCRIPTION
Added standalone Docker instructions for building and running. 

Added `exec` to shell script so now it works when typing `ctrl-c` to stop and `docker stop` works immediately.