### PR TITLE
Remove mathjax.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ enableGitInfo = "true"
 
 [params]
 showFooterCredits = false
+math = false
 
 [frontmatter]
 date = [":git", "lastmod", "date", "publishDate"]


### PR DESCRIPTION
Mathjax seems to be causing a JS error. Removing it as I don't believe it's used.