### PR TITLE
Fix netfilter kernel module name

### DIFF
--- a/content/posts/how-to/determine-using-iptables-or-netfilter.md
+++ b/content/posts/how-to/determine-using-iptables-or-netfilter.md
@@ -28,7 +28,7 @@ lsmod | grep -wi iptables
 If this command generates any output, then NetFilter is in effect on the system:
 
 ```shell
-lsmod | grep -i netfilter
+lsmod | grep -i nf_tables
 ```
 
 ### 2) Run `iptables-save` {#step-2}


### PR DESCRIPTION
I don't think there is a kernel module called `netfilter` could someone verify that? Not sure `nf_tables` is exactly right, either, but that is an actual module at least. I think ip_tables is actually built upon the ntfilter submodule, maybe the the whole page should be renamed accordingly (iptables or nf_tables / nft).